### PR TITLE
Fix `onUpdateAnchors` data parsing

### DIFF
--- a/ARTrackingProvider.js
+++ b/ARTrackingProvider.js
@@ -129,7 +129,8 @@ class ARTrackingProvider extends Component {
       }
     })();
   }
-  async updatePlanes(data) {
+  async updatePlanes(planeData) {
+    const data = planeData && planeData.data;
     if (!data) {
       const anchors = cleanAnchors(await getAnchors(data));
       this.setState({ anchors: anchors }, () => {


### PR DESCRIPTION
`data` object for `updatePlanes` is actually a 

```
data: {
  key: 'someKey',
  data: {
    id: 'someId'
  }
}
```
Propsed change should fix this function and make `onUpdateAnchors` work again.